### PR TITLE
rectified the serialization of the OffsetDateTime field for #12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+
 
         <!-- Test -->
         <dependency>

--- a/src/main/java/org/icgc_argo/workflow_raccoon/utils/JacksonUtils.java
+++ b/src/main/java/org/icgc_argo/workflow_raccoon/utils/JacksonUtils.java
@@ -19,12 +19,17 @@
 package org.icgc_argo.workflow_raccoon.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class JacksonUtils {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper()
+          .registerModule(new JavaTimeModule())
+          .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
   @SneakyThrows
   public static String toJsonString(Object o) {


### PR DESCRIPTION
When collab crashes, the jobs in progress get stuck in the Running state while their respective pods are in error. Running the racoon service should fix the status of these jobs. However, that does not happen due to a problem with the serialization of the OffsetDateTime field in the workflow metadata.